### PR TITLE
nltk download wordnet

### DIFF
--- a/TrainLDA/topic_classify.py
+++ b/TrainLDA/topic_classify.py
@@ -24,6 +24,7 @@ _nltk_stopwords.extend(['could','would','still','shall'])
 container_models = "ldamodel"
 
 def classify(container_name, num_topics):
+    nltk.download('wordnet')
     # List Blobs in the container
     block_blob_service = BlockBlobService(account_name=GUTENBERG_BLOB_ACCOUNT_NAME, 
                                           account_key=GUTENBERG_BLOB_ACCOUNT_KEY) 


### PR DESCRIPTION
nltk.download('wordnet') is essential to download wordnet into /home/user/ntlk_data folder.
`from nltk.corpus import wordnet as wn`
doesn't work unless wordnet is explicitly imported. 
Need to find better ways to preload in a serverless environment.